### PR TITLE
Correct redirections for older Kodamasoft tribute albums [READY TO MERGE]

### DIFF
--- a/public/assets/discography/albums.json
+++ b/public/assets/discography/albums.json
@@ -7,7 +7,7 @@
         "coverColor": "#474a5b",
         "bandcamp": "https://kodamasounds.bandcamp.com/album/moonstruck-analogy-a-type-moon-tribute-album",
         "booth": "https://kodamasoft.booth.pm/items/3264153",
-        "website": "https://moonstruck-analogy.tumblr.com/",
+        "website": "https://kodamasoft.net/releases/moonstruck-analogy",
         "vgmdb": "https://vgmdb.net/album/111959"
     },
 	"fragments-of-gratitude": {
@@ -18,7 +18,7 @@
         "coverColor": "#fff9f3",
         "bandcamp": "https://kodamasounds.bandcamp.com/album/fragments-of-gratitude-a-when-they-cry-tribute-album",
         "booth": "https://kodamasoft.booth.pm/items/4035987",
-        "website": "https://fragmentsofgratitude.tumblr.com/",
+        "website": "https://kodamasoft.net/releases/fragments-of-gratitude",
         "vgmdb": "https://vgmdb.net/album/120016"
     },
 	"katamania": {


### PR DESCRIPTION
Merge only when https://github.com/kodamasoft/kodama-next/tree/replaceTumblrWebsites is merged too